### PR TITLE
Fixed copy paste error in URL travis-ci status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Skip List in Golang #
 
-[![Build Status](https://travis-ci.org/huandu/xstrings.png?branch=master)](https://travis-ci.org/huandu/skiplist)
+[![Build Status](https://travis-ci.org/huandu/skiplist.svg?branch=master)](https://travis-ci.org/huandu/skiplist)
 [![GoDoc](https://godoc.org/github.com/huandu/skiplist?status.svg)](https://godoc.org/github.com/huandu/skiplist)
 
 Skip list is a kind of ordered map and can store any value inside. See [skip list](http://en.wikipedia.org/wiki/Skip_list) wikipedia page to learn more about this data structure.


### PR DESCRIPTION
While browsing around for Go implementations of skip lists, I happened to find a minor copy past error in your readme.
The URL for travis-ci is for your other project xstrings.
By the way, I also changed the request to SVG graphic format, since you use SVG for godoc as well...