### PR TITLE
Remove unused named parameter from Front() method

### DIFF
--- a/skiplist.go
+++ b/skiplist.go
@@ -100,7 +100,7 @@ func (list *SkipList) SetRandSource(source rand.Source) {
 // Front returns the first element.
 //
 // The complexity is O(1).
-func (list *SkipList) Front() (front *Element) {
+func (list *SkipList) Front() *Element {
 	return list.levels[0]
 }
 


### PR DESCRIPTION
This PR is to remove unused named parameter `front` from `list.Front()` method.